### PR TITLE
Allow empty file names

### DIFF
--- a/src/BufferingParser.php
+++ b/src/BufferingParser.php
@@ -105,7 +105,7 @@ final class BufferingParser
             $entry = \substr($entry, $position + 4);
 
             $count = \preg_match(
-                '#^\s*form-data(?:\s*;\s*(?:name\s*=\s*"([^"]+)"|filename\s*=\s*"([^"]+)"))+\s*$#',
+                '#^\s*form-data(?:\s*;\s*(?:name\s*=\s*"([^"]+)"|filename\s*=\s*"([^"]*)"))+\s*$#',
                 $headers["content-disposition"][0] ?? "",
                 $matches
             );


### PR DESCRIPTION
Without this, if a file input is present in a form, but no file is uploaded,
an error is triggered.