### PR TITLE
Rfc7230 namespace changes

### DIFF
--- a/src/BufferedFile.php
+++ b/src/BufferedFile.php
@@ -10,7 +10,7 @@ final class BufferedFile
 
     /**
      * @param list<array{non-empty-string, string}> $rawHeaders Headers produced by
-     * {@see \Amp\Http\Rfc7230::parseRawHeaders()}
+     * {@see \Amp\Http\Http1\Rfc7230::parseHeaderPairs()}
      */
     public function __construct(
         private readonly string $name,

--- a/src/BufferingParser.php
+++ b/src/BufferingParser.php
@@ -3,7 +3,7 @@
 namespace Amp\Http\Server\FormParser;
 
 use Amp\Http\InvalidHeaderException;
-use Amp\Http\Rfc7230;
+use Amp\Http\Http1\Rfc7230;
 use Amp\Http\Server\Request;
 
 /**
@@ -111,7 +111,7 @@ final class BufferingParser
             }
 
             try {
-                $headers = Rfc7230::parseRawHeaders(\substr($entry, 0, $position + 2));
+                $headers = Rfc7230::parseHeaderPairs(\substr($entry, 0, $position + 2));
             } catch (InvalidHeaderException $e) {
                 throw new ParseException("Invalid headers in body part", 0, $e);
             }

--- a/src/StreamedField.php
+++ b/src/StreamedField.php
@@ -10,7 +10,7 @@ use Amp\ByteStream\ReadableStreamIteratorAggregate;
 use Amp\ByteStream\StreamException;
 use Amp\Cancellation;
 use Amp\Http\HttpMessage;
-use Amp\Http\Rfc7230;
+use Amp\Http\Http1\Rfc7230;
 
 /**
  * @implements \IteratorAggregate<int, string>
@@ -25,7 +25,7 @@ final class StreamedField implements ReadableStream, \IteratorAggregate
 
     /**
      * @param list<array{non-empty-string, string}> $rawHeaders Headers produced by
-     * {@see Rfc7230::parseRawHeaders()}
+     * {@see Rfc7230::parseHeaderPairs()}
      */
     public function __construct(
         private readonly string $name,

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -5,7 +5,7 @@ namespace Amp\Http\Server\FormParser;
 use Amp\ByteStream\ReadableIterableStream;
 use Amp\ByteStream\ReadableStream;
 use Amp\Http\InvalidHeaderException;
-use Amp\Http\Rfc7230;
+use Amp\Http\Http1\Rfc7230;
 use Amp\Http\Server\Request;
 use Amp\Pipeline\DisposedException;
 use Amp\Pipeline\Pipeline;
@@ -97,7 +97,7 @@ final class StreamingParser
                 }
 
                 try {
-                    $headers = Rfc7230::parseRawHeaders(\substr($buffer, $offset, $end + 2 - $offset));
+                    $headers = Rfc7230::parseHeaderPairs(\substr($buffer, $offset, $end + 2 - $offset));
                 } catch (InvalidHeaderException $e) {
                     throw new ParseException("Invalid headers in body part", 0, $e);
                 }


### PR DESCRIPTION
- Rfc7230 namespace changes
- Change `parseRawHeaders` to `parseHeaderPairs`